### PR TITLE
Using for global type overload

### DIFF
--- a/config/ConfigLib.sol
+++ b/config/ConfigLib.sol
@@ -49,3 +49,5 @@ library ConfigLib {
     }
 
 }
+
+using ConfigLib for Config global;

--- a/test/RoleHelperLib.sol
+++ b/test/RoleHelperLib.sol
@@ -163,3 +163,5 @@ library RoleHelperLib {
         paramComp = Comparison((scopeConfig & paramCompMask) >> (index * 2));
     }
 }
+
+using RoleHelperLib for IRoles global;

--- a/test/TestSetup.sol
+++ b/test/TestSetup.sol
@@ -21,9 +21,6 @@ import {Ownable} from "@openzeppelin-contracts/contracts/access/Ownable.sol";
 import {ProxyAdmin} from "@openzeppelin-contracts/contracts/proxy/transparent/ProxyAdmin.sol";
 
 contract TestSetup is Test, Configured {
-    using ConfigLib for Config;
-    using RoleHelperLib for IRoles;
-
     uint256 forkId;
 
     ISafe public morphoAdmin;


### PR DESCRIPTION
This can be handy for the Config type overload
This cannot be used to overload interfaces as they are not user-defined types

https://github.com/ethereum/solidity/releases/tag/v0.8.19